### PR TITLE
Read the __version__ from the fitparse/__init__.py without importing it

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,17 @@
-from distutils.core import setup
-import pkg_resources
+# -*- coding: utf-8 -*-
 
+import re
 import sys
+
+from distutils.core import setup
 
 requires = ['six']
 if sys.version_info < (2, 7):
     requires.append('argparse')
 
-version = pkg_resources.require("fitparse")[0].version
+with open('fitparse/__init__.py', 'r') as fd:
+    version = re.search(r'^__version__\s*=\s*[\'"]([^\'"]*)[\'"]',
+                        fd.read(), re.MULTILINE).group(1)
 
 setup(
     name='fitparse',


### PR DESCRIPTION
It avoids having to read an extra VERSION file in the module code itself
and leaves all the ugliness in setup.py, where ugliness belongs. This
is the same technique that the requests module uses.
